### PR TITLE
Fix minikube config set syntax and switch to use docker vm-driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ jobs:
         k8s-version: 1.15.1
     - name: Testing
       run: |
-        minikube config set vm-driver kvm2
-        minikube config set kubernetes-version=v1.15.1
+        minikube config set vm-driver docker
+        minikube config set kubernetes-version v1.15.1
         minikube start
         minikube update-context
         kubectl cluster-info


### PR DESCRIPTION
This fixes the following two issues found while testing this action out in https://github.com/couler-proj/couler/pull/12:

Issue 1:
```
##[error]Process completed with exit code 64.
Run minikube config set vm-driver kvm2
! These changes will take effect upon a minikube delete and then a minikube start
* not enough arguments (1).
usage: minikube config set PROPERTY_NAME PROPERTY_VALUE
```
Details see an example [here](https://github.com/couler-proj/couler/runs/1027072369?check_suite_focus=true).

Issue 2:
```
! 'kvm2' driver reported an issue: exec: "virsh": executable file not found in $PATH
* Suggestion: Install libvirt
* Documentation: https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/

X kvm2 does not appear to be installed
```
Details see an example [here](https://github.com/couler-proj/couler/runs/1027083792?check_suite_focus=true).